### PR TITLE
 PR US03

### DIFF
--- a/CICO/tests.py
+++ b/CICO/tests.py
@@ -1,6 +1,12 @@
+import django.test
 from django.test import TestCase
 from django.urls import reverse
 from .models import CiCoItem
+from .models import UserCICO
+from .models import Cats
+from .models import DeviceRecords
+from .models import Trigger
+from django.contrib.auth import login
 
 
 
@@ -10,19 +16,27 @@ def create_item(text):
 
 class AllTest(TestCase):
 
-    def test_no_e(self):
-        todo = create_item("word")
-        response = self.client.get(reverse("index"))
-        self.assertQuerySetEqual(
-            response.context["cicoitem_list"],
-            [todo]
-        )
+    def test(self):
+        client = django.test.Client(REMOTE_ADDR='127.0.0.1')
 
-    def test_with_e(self):
-        todo = create_item("word")
-        response = self.client.get(reverse("pageE"))
+        user = UserCICO.objects.create_user('my-user-name', password="testpwd", ownedDevice=12)
+        self.assertTrue(client.login(username='my-user-name', password="testpwd"))
+        cat = Cats.objects.create(ownerId=user, name="testCat")
+        newRecord = DeviceRecords.objects.create(deviceId=user, event="IN", isCat=True)
+
+        newTrigger = Trigger.objects.create(catId=cat, recordId=newRecord)
+        print(cat)
+        session = client.session
+        session['IP'] = "127.0.0.1"
+        session.save()
+
+
+        response = client.get(reverse('profileIndex', kwargs={'listButton':"None"}))
+        #print(response.context["recordList"][0]["recordId"])
+
+
         self.assertQuerySetEqual(
-            response.context["cicoitem_list"],
-            []
+            str(response.context["recordList"][0]["recordId"]),
+            str(newRecord.recordId)
         )
 

--- a/CICO/tests.py
+++ b/CICO/tests.py
@@ -6,13 +6,22 @@ from .models import UserCICO
 from .models import Cats
 from .models import DeviceRecords
 from .models import Trigger
+from django.template.loader import render_to_string
 from django.contrib.auth import login
+import math
 
 
 
 def create_item(text):
     return CiCoItem.objects.create(text=text)
 
+
+def createSession():
+    testClient = django.test.Client(REMOTE_ADDR='127.0.0.1')
+    testSession = testClient.session
+    testSession['IP'] = "127.0.0.1"
+    testSession.save()
+    return testClient, testSession
 
 class AllTest(TestCase):
 
@@ -39,4 +48,51 @@ class AllTest(TestCase):
             str(response.context["recordList"][0]["recordId"]),
             str(newRecord.recordId)
         )
+
+    def testDisplayOnProfileIndex(self):
+        """
+        Tests that the list displays upon entering profileIndex by testing that a table row appears if there's a cat record
+        """
+        testClient, testSession = createSession()
+
+
+        testUser = UserCICO.objects.create_user('my-user-name', password="testpwd", ownedDevice=12)
+        self.assertTrue(testClient.login(username='my-user-name', password="testpwd"))
+        testCat = Cats.objects.create(ownerId=testUser, name="testCat")
+        testRecord = DeviceRecords.objects.create(deviceId=testUser, event="IN", isCat=True)
+        testTrigger = Trigger.objects.create(catId=testCat, recordId=testRecord)
+
+        response = testClient.get(reverse('profileIndex', kwargs={'listButton': "None"}))
+
+        self.assertContains(response, '<tr id=row_1>')
+
+    def testListContainsAll(self):
+        """
+        Tests that the list obtained by the page contains all records when going through all pages of the list
+        """
+        testClient, testSession = createSession()
+        testSession['listStart'] = 0
+        testUser = UserCICO.objects.create_user('my-user-name', password="testpwd", ownedDevice=12)
+        self.assertTrue(testClient.login(username='my-user-name', password="testpwd"))
+        testCat = Cats.objects.create(ownerId=testUser, name="testCat")
+        testRecord = DeviceRecords.objects.create(deviceId=testUser, event="IN", isCat=True)
+        testTrigger = Trigger.objects.create(catId=testCat, recordId=testRecord)
+
+        testRecord2 = DeviceRecords.objects.create(deviceId=testUser, event="OUT", isCat=True)
+        Trigger.objects.create(catId=testCat, recordId=testRecord2)
+
+        testRecord3 = DeviceRecords.objects.create(deviceId=testUser, event="IN", isCat=True)
+        Trigger.objects.create(catId=testCat, recordId=testRecord3)
+        response = testClient.get(reverse('profileIndex', kwargs={'listButton': "None"}))
+        testList = []
+        for i in range(math.ceil(len(DeviceRecords.objects.all())/2)):
+            testSession['listStart'] = i * 2
+            for j in range(len(response.context["recordList"])):
+                testList.append(response.context["recordList"][j]["recordId"])
+            response = testClient.get(reverse('profileIndex', kwargs={'listButton': "ancien"}))
+
+        self.assertEqual(testList, list(DeviceRecords.objects.values_list('recordId', flat=True))[::-1])
+
+
+
 

--- a/CICO/urls.py
+++ b/CICO/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("connexion/<int:formId>", views.connection, name ="connexion"),
     path("faq",views.faq, name = "faq"),
     path("contact",views.contact, name = "contact"),
-    path("profileIndex", views.profileIndex, name ="profileIndex"),
+    path("profileIndex/<str:listButton>", views.profileIndex, name ="profileIndex"),
     path("commande", views.commande, name ="commande"),
 
 

--- a/CICO/views.py
+++ b/CICO/views.py
@@ -3,6 +3,9 @@ from django.views.generic import ListView
 from .models import CiCoItem
 from .models import Statuses
 from .models import UserCICO
+from .models import Cats
+from .models import DeviceRecords
+from .models import Trigger
 from django.shortcuts import redirect
 from CICO.forms import ContactUsForm
 from CICO.forms import ConnectionForm
@@ -15,6 +18,21 @@ from django.contrib.auth import logout
 logger = logging.getLogger('django')
 from django.http import HttpResponse
 
+from django.db.models import F
+
+LIST_SIZE = 2
+
+def UpdateList(request, deviceId):
+    recordList = GetRecords(deviceId)[::-1]
+    newList = recordList[request.session['listStart']:request.session['listStart'] + LIST_SIZE]
+    if len(newList) == 0:
+        newList = recordList[request.session['listStart'] - LIST_SIZE:request.session['listStart']]
+        request.session['listStart'] -= LIST_SIZE
+    return newList
+
+def GetRecords(deviceId):
+    querySet = DeviceRecords.objects.all().annotate(catName=F('trigger__catId__name'))
+    return querySet.values()
 
 def Empty(request):
     return redirect("CICO/")
@@ -38,7 +56,6 @@ def vue(request):
 
 
 def connection(request, formId):
-
     if (formId == 0):
         logout(request)
         request.session['IP'] = ""
@@ -48,13 +65,14 @@ def connection(request, formId):
         if (request.method == "POST"):
             form = ConnectionForm(request.POST)
             if form.is_valid():
-                #newItem = CiCoItem(text=form.cleaned_data["message"])
-                #newItem.save()
-                user = authenticate(username=form.cleaned_data["identification"], password=form.cleaned_data["password"])
+                # newItem = CiCoItem(text=form.cleaned_data["message"])
+                # newItem.save()
+                user = authenticate(username=form.cleaned_data["identification"],
+                                    password=form.cleaned_data["password"])
                 if user is not None:
                     login(request, user)
                     request.session['IP'] = request.META.get("REMOTE_ADDR")
-                    request.session['user'] = user.id                # A backend authenticated the credentials
+                    request.session['user'] = user.id  # A backend authenticated the credentials
                     return redirect('profileIndex')
                 else:
                     # No backend authenticated the credentials
@@ -65,8 +83,8 @@ def connection(request, formId):
         if (request.method == "POST"):
             form = NewAccountForm(request.POST)
             if form.is_valid():
-                if form.cleaned_data["email"] in UserCICO.objects.values_list("email", flat = True):
-                    logger.info("This email is already used") #these texts will need to be displayed on the page
+                if form.cleaned_data["email"] in UserCICO.objects.values_list("email", flat=True):
+                    logger.info("This email is already used")  # these texts will need to be displayed on the page
                 elif form.cleaned_data["password"] != form.cleaned_data["confirmPassword"]:
                     logger.info("Passwords not identical")
                 else:
@@ -75,8 +93,7 @@ def connection(request, formId):
                                                       username=form.cleaned_data["identification"])
                     newUser.set_password(form.cleaned_data["password"])
                     newUser.save()
-                    request.session['user'] = newUser.id  # A backend authenticated the credentials
-                    return redirect('profileIndex')
+                    return redirect('profileIndex/None')
         else:
             form = NewAccountForm()
 
@@ -87,7 +104,7 @@ def connection(request, formId):
             if form.is_valid():
                 emails = UserCICO.objects.values_list('email')
                 if form.cleaned_data["email"] in emails:
-                    #send mail
+                    # send mail
                     ...
         else:
             form = RequestNewPasswordForm()
@@ -95,18 +112,28 @@ def connection(request, formId):
     return render(request, 'CICO/connexion.html', {"form": form})
 
 
-def profileIndex(request):
+def profileIndex(request, listButton="None"):
+    if listButton == "None":
+        request.session['listStart'] = 0
+    elif listButton == "récent":
+        request.session['listStart'] = max(0, request.session[
+            'listStart'] - LIST_SIZE)  # the max function is used to prevent the substraction from resulting in a negative
+    elif listButton == "ancien":
+        request.session['listStart'] += LIST_SIZE
+
     if not checkIP(request):
         return render(request, 'CICO/unauthorized.html', status=401)
     items = CiCoItem.objects.all()
     print(request.user)
     print(request.META.get("REMOTE_ADDR"))
     user = request.user
+    recordList = UpdateList(request, UserCICO.objects.get(username=request.user).ownedDevice)
+
     if request.user.is_authenticated:
-        return render(request, 'CICO/profileIndex.html', {"items": items, "user": user.username})
+        return render(request, 'CICO/profileIndex.html',
+                      {"items": items, "user": user.username, "recordList": recordList})
     else:
         return render(request, 'CICO/unauthorized.html', status=401)
-
 
 
 def faq(request):
@@ -126,7 +153,7 @@ class PageMotE(ListView):
     template_name = "CICO/pageE.html"
 
     def get_queryset(self):
-        return CiCoItem.objects.filter(text__icontains= "e")
+        return CiCoItem.objects.filter(text__icontains="e")
 
 
 class PageStatus(ListView):

--- a/CICO/views.py
+++ b/CICO/views.py
@@ -40,6 +40,7 @@ def Empty(request):
 # Create your views here.
 
 def checkIP(request):
+    print(request.session['IP'], request.META.get("REMOTE_ADDR"))
     if request.session['IP'] != request.META.get("REMOTE_ADDR"):
         return False
     else:
@@ -73,7 +74,7 @@ def connection(request, formId):
                     login(request, user)
                     request.session['IP'] = request.META.get("REMOTE_ADDR")
                     request.session['user'] = user.id  # A backend authenticated the credentials
-                    return redirect('profileIndex')
+                    return redirect('profileIndex', listButton="None")
                 else:
                     # No backend authenticated the credentials
                     logger.info("login failed")
@@ -93,7 +94,7 @@ def connection(request, formId):
                                                       username=form.cleaned_data["identification"])
                     newUser.set_password(form.cleaned_data["password"])
                     newUser.save()
-                    return redirect('profileIndex/None')
+                    return redirect('profileIndex', listButton="None")
         else:
             form = NewAccountForm()
 
@@ -122,6 +123,7 @@ def profileIndex(request, listButton="None"):
         request.session['listStart'] += LIST_SIZE
 
     if not checkIP(request):
+        print("no")
         return render(request, 'CICO/unauthorized.html', status=401)
     items = CiCoItem.objects.all()
     print(request.user)

--- a/commit_message.txt
+++ b/commit_message.txt
@@ -1,10 +1,36 @@
-Ajout du fichier dependencies
+#62 Réalisation de l'US03, historique des entrées-sorties
 
-Le fichier dependencies.txt contiens tout les packages nécessaires au fonctionnement du code.
+Qui: Lucas (PirLucas)
 
-Pour l'utiliser:
-depuis le terminal dans le dossier  du projet-> pip install -r dependencies.txt
+Quoi: US 3: En tant qu'utilisateur, je veux avoir acces a un historique des entrées et sorties de tout mes chat dès ma connexion, afin d'avoir un apperçu rapide du comportement de mes chats.
 
-Pour le mettre a jour:
-Si vous avez installé un nouveau package qui sera requis par la suite->pip freeze > dependencies.txt
-cela réecrira le fichier avec tout les packages, y compris le nouveau.
+Ajout sur la page d'accueil du profil utilisateur d'une liste générée à partir des enregistrement que sa chatière. Cette liste contiens dans l'ordre chronologique descendant tout les passages enregistrés.
+Un nombre limité d'élément s'affiche a la fois, l'utilisateur dispose de deux boutons pour naviguer dans le reste de la liste.
+
+Pourquoi: Cette fonctionnalité a été rajoutée pour permettre à l'utilisateur d'avoir un apreçu rapide de tout les passages récents de ses chats dès qu'il se connecte
+
+Comment:
+
+urls.py: L'URL "profileIndex" a été modifiée pour utiliser un parametre "listButton", ce parametre contiens une chaine de caractère envoyée par un des deux boutons ajoutés à la page profileIndex.html, il est utilisé par la vue profileIndex pour obtenir une nouvelle liste a afficher à l'écran. Ce parametre doit valoir "None" quand on accede à cette page sans avoir utilisé un de ces deux boutons.
+
+views.py:
+-Création de la constante LIST_SIZE, qui représente la ne nombre d'éléments de la liste qui seront affiché sur la page
+
+-Création de la fonction "GetRecords" qui cherche dans la DB l'ensemble des enregistrements associés à un deviceId (=un utilisateur unique) et retourne le résultat sous forme de liste
+
+-Création de la variable de session "listStart" qui représente l'indice du premier élément qui sera affiché à l'écran. Cet indice est incrémenté ou décrémenté en fonction du bouton de navigation utilisé. Si la décrémentation ou incrémentation sortirait de la liste des enregistrements, sa valeur reviens à son état précédent.
+
+-Création de la fonctione "UpdateList" qui utilise le retour de GetRecords, l'inverse afin d'avoir la liste dans l'ordre chronologique décroissant (du plus récent au plus ancien) et retourne une nouvelle liste de longueur LIST_SIZE qui commence à partir de l'indice contenu dans la variable de session "listStart"
+
+-Modification de profileIndex afin d'utiliser le parametre "listButton" envoyé dans l'url. Le parametre "récent" décrémente la valeur de "listStart" de LIST_SIZE, afin d'obtenir les éléments plus récent de la liste d'énregistrements. Le parametre "ancien" incrémente la valeur de "listStart" de LIST_SIZE.
+La variable "recordList" contiens le retour de la fonction "UpdateList", cette variable est envoyée à la page profileIndex.html pour être affichée.
+
+templates/profileIndex.html:
+
+-Ajout d'une boucle parcourant la liste recordList qui pour chaque élément crée une cellule de tableau contenant le nom du chat, l'évenement et la date
+-Ajout des boutons de navigations redirigeant sur la même page, avec le paramètre utilisé par la vue "profileIndex"
+
+notes:
+- Seul le contenu de la liste qui est affiché est envoyé, afin de ne pas demander toute la liste des enregistrements a chaque fois mais ça implique que la navigation dans la liste rafraichisse toute la page, car ce n'est pas possible de modifier dynamiquement le contenu de celle-ci sans utiliser du JS pour faire une requête ajax
+
+

--- a/templates/CICO/profileIndex.html
+++ b/templates/CICO/profileIndex.html
@@ -58,14 +58,26 @@
         </tr>
       </thead>
       <tbody>
+
+      {% for record in recordList  %}
+
         <tr>
-          <td>Cell 1</td>
+          <td>{{record.catName}}</td>
+          <td>{{record.event}}</td>
+          <td>{{record.time}}</td>
         </tr>
-        <tr>
-          <td>Cell 3</td>
-        </tr>
+
+
+      {% endfor %}
+
       </tbody>
     </table>
+      <a href='{% url "profileIndex" listButton="récent"%}'>
+        <button>récent</button>
+      </a>
+      <a href='{% url "profileIndex" listButton="ancien"%}'>
+        <button>ancien</button>
+      </a>
   </div>
 </div>
 

--- a/templates/CICO/profileIndex.html
+++ b/templates/CICO/profileIndex.html
@@ -61,7 +61,7 @@
 
       {% for record in recordList  %}
 
-        <tr>
+        <tr id=row_{{forloop.counter}}>
           <td>{{record.catName}}</td>
           <td>{{record.event}}</td>
           <td>{{record.time}}</td>


### PR DESCRIPTION
#62 

Commit 1:
Qui: Lucas (PirLucas)

Quoi: US 3: En tant qu'utilisateur, je veux avoir acces a un historique des entrées et sorties de tout mes chat dès ma connexion, afin d'avoir un apperçu rapide du comportement de mes chats.

Ajout sur la page d'accueil du profil utilisateur d'une liste générée à partir des enregistrement que sa chatière. Cette liste contiens dans l'ordre chronologique descendant tout les passages enregistrés.
Un nombre limité d'élément s'affiche a la fois, l'utilisateur dispose de deux boutons pour naviguer dans le reste de la liste.

Pourquoi: Cette fonctionnalité a été rajoutée pour permettre à l'utilisateur d'avoir un apreçu rapide de tout les passages récents de ses chats dès qu'il se connecte

Comment:

urls.py: L'URL "profileIndex" a été modifiée pour utiliser un parametre "listButton", ce parametre contiens une chaine de caractère envoyée par un des deux boutons ajoutés à la page profileIndex.html, il est utilisé par la vue profileIndex pour obtenir une nouvelle liste a afficher à l'écran. Ce parametre doit valoir "None" quand on accede à cette page sans avoir utilisé un de ces deux boutons.

views.py:
-Création de la constante LIST_SIZE, qui représente la ne nombre d'éléments de la liste qui seront affiché sur la page

-Création de la fonction "GetRecords" qui cherche dans la DB l'ensemble des enregistrements associés à un deviceId (=un utilisateur unique) et retourne le résultat sous forme de liste

-Création de la variable de session "listStart" qui représente l'indice du premier élément qui sera affiché à l'écran. Cet indice est incrémenté ou décrémenté en fonction du bouton de navigation utilisé. Si la décrémentation ou incrémentation sortirait de la liste des enregistrements, sa valeur reviens à son état précédent.

-Création de la fonctione "UpdateList" qui utilise le retour de GetRecords, l'inverse afin d'avoir la liste dans l'ordre chronologique décroissant (du plus récent au plus ancien) et retourne une nouvelle liste de longueur LIST_SIZE qui commence à partir de l'indice contenu dans la variable de session "listStart"

-Modification de profileIndex afin d'utiliser le parametre "listButton" envoyé dans l'url. Le parametre "récent" décrémente la valeur de "listStart" de LIST_SIZE, afin d'obtenir les éléments plus récent de la liste d'énregistrements. Le parametre "ancien" incrémente la valeur de "listStart" de LIST_SIZE.
La variable "recordList" contiens le retour de la fonction "UpdateList", cette variable est envoyée à la page profileIndex.html pour être affichée.

templates/profileIndex.html:

-Ajout d'une boucle parcourant la liste recordList qui pour chaque élément crée une cellule de tableau contenant le nom du chat, l'évenement et la date
-Ajout des boutons de navigations redirigeant sur la même page, avec le paramètre utilisé par la vue "profileIndex"

notes:
- Seul le contenu de la liste qui est affiché est envoyé, afin de ne pas demander toute la liste des enregistrements a chaque fois mais ça implique que la navigation dans la liste rafraichisse toute la page, car ce n'est pas possible de modifier dynamiquement le contenu de celle-ci sans utiliser du JS pour faire une requête ajax

Commit 2+3: 
Mise en place des tests unitaires pour l'US 3
test 1: Teste qu'un tableau contenant les informations des enregistrement s'affiche lors de l'arrivée sur la page profileIndex

test2: Teste que L'ensemble de la table des enregistrement pour un utilisateur s'affiche bien, en considérant qu'on navigue dans la liste