### PR TITLE
Modification et amélioration de la modification de profil

### DIFF
--- a/CICO/tests.py
+++ b/CICO/tests.py
@@ -175,3 +175,40 @@ def get_image_from_url(url):
         return BytesIO(response.content), 'test_image.jpg'  # 'test_image.jpg' can be any filename with a valid extension
     else:
         raise Exception("Failed to download image")
+
+
+class EditProfileTests(TestCase):
+
+    def testSameNameError(self):
+        """
+        Tests that trying to change your name to an already existing name returns a json with "already used"
+        """
+        testClient, testSession = createSession()
+
+        alreadyExistingUser = UserCICO.objects.create_user('user', password="pwd", ownedDevice=11)
+
+        testUser = UserCICO.objects.create_user('my-user-name', password="testpwd", ownedDevice=12)
+        self.assertTrue(testClient.login(username='my-user-name', password="testpwd"))
+
+        response = testClient.post(reverse("profile"), {'param': 'username', 'value':'user'})
+        self.assertJSONEqual(
+            str(response.content, encoding='utf8'),
+            {'message': 'already used'}
+        )
+
+    def testSameNameSuccess(self):
+        """
+        Tests that trying to change your name to a name that doesnt already exists returns a json with "saved"
+        """
+        testClient, testSession = createSession()
+
+        alreadyExistingUser = UserCICO.objects.create_user('user', password="pwd", ownedDevice=11)
+
+        testUser = UserCICO.objects.create_user('my-user-name', password="testpwd", ownedDevice=12)
+        self.assertTrue(testClient.login(username='my-user-name', password="testpwd"))
+
+        response = testClient.post(reverse("profile"), {'param': 'username', 'value':'newuser'})
+        self.assertJSONEqual(
+            str(response.content, encoding='utf8'),
+            {'message': 'saved'}
+        )

--- a/CICO/views.py
+++ b/CICO/views.py
@@ -409,14 +409,19 @@ def profile(request):
         return render(request, 'CICO/unauthorized.html', status=401)
 
     user = UserCICO.objects.get(username=request.user)
-
     if request.method == "POST":
-        if list(request.POST.keys())[1] == "deleteAccount":
+        if "deleteAccount" in list(request.POST.keys()):
             user.delete()
             return redirect("connexion", formType="connexion")
-        setattr(user,str(list(request.POST.keys())[1]), str(list(request.POST.values())[1]))
+        if (str(list(request.POST.values())[0]) == "username"):
+            if str(list(request.POST.values())[1]) in UserCICO.objects.values_list("username", flat=True):
+                return JsonResponse({'message': "already used"})
+
+
+
+        setattr(user,str(list(request.POST.values())[0]), str(list(request.POST.values())[1]))
         user.save()
-        return redirect("profile")
+        return JsonResponse({'message': "saved"})
     else:
         return render(request, "CICO/profile.html", {"user":user})
 

--- a/templates/CICO/profile.html
+++ b/templates/CICO/profile.html
@@ -3,9 +3,10 @@
 <script>
     function edit(id, value) {
         document.getElementById(id).innerHTML=`
-            <form action="" method="post" >
+            <form method="post" id="form${id}" class="paramForm">
             {% csrf_token %}
-                <input type="text" name=${ id } value="${ value }"/>
+                <input type="hidden" name="param" value="${id}"/>
+                <input type="text" name="value" value="${ value }"/>
                 <input type="submit" value="save"/>
             </form>
             `
@@ -30,6 +31,30 @@
 
 
 </script>
+<script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
+
+    <script type="text/javascript">
+    $(document).on('submit','.paramForm',function(e){
+        console.log("a")
+        e.preventDefault();
+        $.ajax({
+            type:'POST',
+            url:'{% url "profile" %}',
+            data:
+            {
+                param:$('input[name="param"]').val(),
+                value:$('input[name="value"]').val(),
+                csrfmiddlewaretoken:$('input[name=csrfmiddlewaretoken]').val()
+            },
+            success:function(response){
+                  alert(response.message);
+                    },
+            error: function () {
+                alert("Déjà pris");
+            }
+            })
+        });
+    </script>
 
 
 


### PR DESCRIPTION
Problème 1: La page entière se rafraichissait quand on enregistrait une modif, ce qui effaçait les modifs pas encore enregistrées
Problème 2: Si on modifiait le nom de profil en un nom qui existe déjà dans la DB, ça retournait une page d'erreur

Le problème 1 a été corrigé en travaillant avec une requête ajax afin de faire de l'asynchrone
Le problème 2 a été corrigé en affichant un avertissement à l'utilisateur