### PR TITLE
BUGFIX - Modifie la méthode clean du modèle Cats pour autoriser les noms de chats identiques par utilisateur

### DIFF
--- a/CICO/models.py
+++ b/CICO/models.py
@@ -69,8 +69,9 @@ class Cats(models.Model):
     string_value5 = models.CharField(max_length=200, blank=True)
 
     def clean(self):
-        if Cats.objects.filter(name=self.name).exists():
+        if Cats.objects.filter(name=self.name, ownerId=self.ownerId_id).exclude(catId=self.catId).exists():
             raise ValidationError("A cat with this name already exists for this user.")
+
                                   
     def save(self, *args, **kwargs):
         self.clean()

--- a/CICO/views.py
+++ b/CICO/views.py
@@ -236,7 +236,7 @@ def profileIndex(request):
 
         end_date = timezone.now()
 
-        start_date = end_date - timedelta(days=6)
+        start_date = end_date - timedelta(days=7)
 
         triggers = Trigger.objects.filter(
             catId__in=user_cats,


### PR DESCRIPTION
Dans le programme il y avait un comportément innatendu où deux utilisateurs ne peuvent pas avoir des chats avec le même nom, exemple:

- *User1* crée un chat "Toto" dans son compte.
- *User2* essaye de créer un chat "Toto" dans son compte aussi, mais le programme lui dit qu'il y a eu un erreur.

Ce commit ajuste la logique de la méthode clean dans le modèle Cats. Ça a été fait en filtrant les chats par nom et par identifiant du propriétaire (ownerId).

Avant, cette méthode empêchait la création de chats avec des noms identiques dans l'ensemble de la base de données. Avec ce changement, elle permet désormais à différents utilisateurs d'avoir des chats portant le même nom, tout en empêchant un utilisateur individuel d'avoir plusieurs chats avec le même nom.

Cette mise à jour garantit une plus grande flexibilité pour nommer des chats tout en maintenant l'intégrité des données.