### PR TITLE
Envoie d'une photo hardcodée plutôt qu'une photo prise par la caméra 

### DIFF
--- a/Electronique/send_data_photo.py
+++ b/Electronique/send_data_photo.py
@@ -1,0 +1,24 @@
+import requests
+import uuid
+
+# URL de l'API
+url = "https://cico.ovh:443/CICO/postRaspberry"
+
+# Identifiant de l'appareil
+deviceId = 1
+
+def send_data(photo):
+    # Token et cookies
+    headers = {'X-CSRFToken': uuid.uuid1() }
+    cookies = {'csrftoken': uuid.uuid1() }
+    # Effectuer la requête POST
+    response = requests.post(url, data={"deviceId": deviceId}, files=photo, headers=headers, cookies=cookies, verify=True)
+    print(response.text)
+
+# Chemin de l'image
+image_path = 'livre.JPG'  
+
+# Ouvrir l'image et l'envoyer
+with open(image_path, 'rb') as image_file:
+    image_data = {'image': image_file}
+    send_data(image_data)


### PR DESCRIPTION
## Description de la fonctionnalité
Normalement la caméra prend une suite de 4 photos et ensuite, le rasberry les envoye en HTTPS au serveur web distant. 
(venant des commit : 492e0983f7fb4989bd50904a63e10f151c347299 & c358744c97915043c215298b2d5e65a8b12b26b2)

## Description du problème
Cependant la caméra ne fonctionnant plus, le code doit être modifié afin que le rasperry envoie une image harcodée (enregistrée directement dans le rasberry) afin que l'envoie vers le serveur soit toujours possible.

Le fix est évidemment temporaire le temps qu'une nouvelle caméra soit achetée.

## Fix du problème
Le code a été modifié afin de ne plus envoyer qu'une seule photo au lieu de 4. On précise donc juste le chemin de la photo.

## Note importante :
On ne passe plus par le fichier _main.py_ pour lancer l'ancien fichier _send\_data.py_ car la caméra n'est plus utilisée et lancée dans ce fichier. L'envoie peut donc se faire directement depuis le nouveau fichier _send\_data\_photo.py_ en tapant la commande (dans la console du rasberry) _sudo python  send\_data\_photo.py_ .